### PR TITLE
[Fix] GUI displayed a successful prompt when a user tried to open a file that did not exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@ build/
 .idea/jarRepositories.xml
 .idea/compiler.xml
 .idea/libraries/
+.idea/codeStyles/
+.idea/jsonSchemas.xml
+.idea/material_theme_project_new.xml
+.idea/vcs.xml
 *.iws
 *.iml
 *.ipr
@@ -39,4 +43,4 @@ bin/
 .vscode/
 
 ### Mac OS ###
-.DS_Store
+.DS_Store!/.idea/vcs.xml

--- a/src/main/java/dev/berikai/BitwigTheme/Main.java
+++ b/src/main/java/dev/berikai/BitwigTheme/Main.java
@@ -77,9 +77,11 @@ public class Main {
         System.out.println("Theme successfully exported to: " + path);
     }
 
-    public static void applyTheme(String bitwig_path, String path, JarNode jar) throws IOException {
+    public static int applyTheme(String bitwig_path, String path, JarNode jar) throws IOException {
         System.out.println("Applying theme from: " + path);
         File file = new File(path);
+        
+        // If the operation succeeds, return 1
         if (file.exists() && file.canRead()) {
             ThemeClass windowThemeClass = new WindowThemeClass(jar.getNodes());
             ThemeClass arrangerThemeClass = new ArrangerThemeClass(jar.getNodes());
@@ -92,8 +94,11 @@ public class Main {
 
             jar.export(bitwig_path);
             System.out.println("Theme successfully applied from: " + path);
-        } else {
-            System.err.println("Failed to apply theme. File not found or permission issue.");
+            return 1;
         }
+        
+        // Otherwise return 0 so that client can handle this
+        System.err.println("Failed to apply theme. File not found or permission issue.");
+        return 0;
     }
 }

--- a/src/main/java/dev/berikai/BitwigTheme/UI/MainUI.java
+++ b/src/main/java/dev/berikai/BitwigTheme/UI/MainUI.java
@@ -27,8 +27,18 @@ public class MainUI extends JFrame {
         change.addActionListener(e -> {
             ThemeChooser themeChooser = new ThemeChooser("Open");
             try {
-                Main.applyTheme(jar.getPath(), themeChooser.getSelectedFile().getPath(), jar);
-                JOptionPane.showMessageDialog(null, "Theme successfully applied from: " + themeChooser.getSelectedFile().getPath(), "Successful!", JOptionPane.INFORMATION_MESSAGE);
+                final int result = Main.applyTheme(jar.getPath(), themeChooser.getSelectedFile().getPath(), jar);
+                if (result == 0) {
+                    JOptionPane.showMessageDialog(null,
+                            "Theme " + themeChooser.getSelectedFile().getPath() + " does not exist, could not be accessed, or is corrupted.",
+                            "Error!",
+                            JOptionPane.INFORMATION_MESSAGE);
+                } else {
+                    JOptionPane.showMessageDialog(null,
+                            "Theme successfully applied from: " + themeChooser.getSelectedFile().getPath(),
+                            "Successful!",
+                            JOptionPane.INFORMATION_MESSAGE);
+                }
             } catch (IOException ex) {
                 throw new RuntimeException(ex);
             }


### PR DESCRIPTION
When using the GUI version of the editor to apply a theme from a JSON or YAML file, when a user selected a file that did not exists, the UI would popup a "Successful!" prompt window even when it would correctly print an error string in the terminal.

I added a return type to the `Main.applyTheme` function so that when used in `MainUI.java`, a proper error prompt would show up for such failures.