### PR TITLE
fix: match theme color keys exactly

### DIFF
--- a/src/main/java/dev/berikai/BitwigTheme/core/impl/ColorPatchClass.java
+++ b/src/main/java/dev/berikai/BitwigTheme/core/impl/ColorPatchClass.java
@@ -496,7 +496,7 @@ public class ColorPatchClass extends PatchClass {
         int hexSlot = methodNode.maxLocals++;
         il.add(new VarInsnNode(Opcodes.ASTORE, hexSlot));
 
-        // "if ((line = line.trim()).startsWith("//") || line.isEmpty() || !hex.startsWith("#") || this.colorName == null || !line.startsWith(this.colorName)) continue;"
+        // "if ((line = line.trim()).startsWith("//") || line.isEmpty() || !hex.startsWith("#") || this.colorName == null || !line.startsWith(this.colorName + ": ")) continue;"
         // This line is really complex in terms of bytecode control flow
         // Here is the corresponding bytecode:
         //        aload line
@@ -519,6 +519,8 @@ public class ColorPatchClass extends PatchClass {
         //        aload line
         //        aload this
         //        getfield gPj.colorName Ljava/lang/String;
+        //        ldc ": "
+        //        invokevirtual java/lang/String.concat (Ljava/lang/String;)Ljava/lang/String;
         //        invokevirtual java/lang/String.startsWith (Ljava/lang/String;)Z
         //        ifne J
         //        goto tryStart_B
@@ -546,6 +548,8 @@ public class ColorPatchClass extends PatchClass {
         il.add(new VarInsnNode(Opcodes.ALOAD, lineSlot));
         il.add(new VarInsnNode(Opcodes.ALOAD, 0/*this*/));
         il.add(new FieldInsnNode(Opcodes.GETFIELD, PatchClass.mappings.get("ColorClass"), "colorName", "Ljava/lang/String;"));
+        il.add(new LdcInsnNode(": "));
+        il.add(new MethodInsnNode(Opcodes.INVOKEVIRTUAL, "java/lang/String", "concat", "(Ljava/lang/String;)Ljava/lang/String;"));
         il.add(new MethodInsnNode(Opcodes.INVOKEVIRTUAL, "java/lang/String", "startsWith", "(Ljava/lang/String;)Z"));
         il.add(new JumpInsnNode(Opcodes.IFNE, labelNode_J));
         il.add(new JumpInsnNode(Opcodes.GOTO, tryStart_B));


### PR DESCRIPTION
## Summary
- Match theme color keys exactly when reading `theme.bte`
- Prevent short keys like `Clip` from matching longer keys like `Clip Automation Color`
- Fixes incorrect clip colors caused by prefix collisions in patched Bitwig 6.x themes

## Context
The injected color lookup previously used `line.startsWith(this.colorName)`. For a color named `Clip`, that can match the first `Clip...` entry in a theme file, such as `Clip Automation Color`, `Clip Content Automation Fill Color`, or `Clip Automation Button Color`.

This changes the injected matcher to require the exact key prefix: `this.colorName + ": "`.

Closes #26.

## Verification
- Built with Java 21 using `./gradlew clean jar --no-daemon`
- Ad-hoc patched a disposable copy of Bitwig Studio 6.1 Beta 2 `bitwig.jar`
- Verified injected bytecode contains `java/lang/String.concat` before `String.startsWith`
- Verified no unrelated hardcoded-color experiment remains in the patcher
